### PR TITLE
MockServer: Request forward o.b.v. request-regel

### DIFF
--- a/src/main/java/nl/praegus/fitnesse/slim/fixtures/mockserver/MockServer.java
+++ b/src/main/java/nl/praegus/fitnesse/slim/fixtures/mockserver/MockServer.java
@@ -102,6 +102,26 @@ public class MockServer extends SlimFixture {
     }
 
     /**
+     * forwards a request to the target host/port and path for any request that matches the rules defined in the
+     * request matching hashmap
+     * Usage: | set forward for | [map: requestMatching] | to | target | with path | fwpath |
+     *
+     * @param requestMatching    a map object containing request filter rules. Valid rules are: method, path, content-type,
+     *                           cookies, querystring, headers, body
+     * @param target             The host/port to forward to (http(s)://host[:port])
+     * @param fwPath             The path to forward to
+     */
+    public void setForwardForToWithPath(Map<String, Object> requestMatching, String target, String fwPath) {
+        validatePath(fwPath);
+        SocketAddress targetAddress = getTargetAddress(target);
+        mock.when(httpRequestMatching(requestMatching))
+                .forward(HttpOverrideForwardedRequest.forwardOverriddenRequest(
+                    request()
+                        .withPath(fwPath)
+                        .withSocketAddress(targetAddress.getHost(), targetAddress.getPort(), targetAddress.getScheme())));
+    }
+
+    /**
      * Forward any request on the given path to the target host/port
      *
      * @param path   The path to forward requests for

--- a/src/main/java/nl/praegus/fitnesse/slim/fixtures/mockserver/MockServer.java
+++ b/src/main/java/nl/praegus/fitnesse/slim/fixtures/mockserver/MockServer.java
@@ -113,6 +113,7 @@ public class MockServer extends SlimFixture {
      */
     public void setForwardForToWithPath(Map<String, Object> requestMatching, String target, String fwPath) {
         validatePath(fwPath);
+        validateTarget(target);
         SocketAddress targetAddress = getTargetAddress(target);
         mock.when(httpRequestMatching(requestMatching))
                 .forward(HttpOverrideForwardedRequest.forwardOverriddenRequest(
@@ -129,6 +130,7 @@ public class MockServer extends SlimFixture {
      */
     public void forwardRequestsOnTo(String path, String target) {
         validatePath(path);
+        validateTarget(target);
         SocketAddress targetAddress = getTargetAddress(target);
         createForwardRule(path, targetAddress.getHost(), targetAddress.getPort(), HttpForward.Scheme.valueOf(targetAddress.getScheme().name()));
     }
@@ -144,6 +146,7 @@ public class MockServer extends SlimFixture {
     public void forwardRequestsOnToWithPath(String path, String target, String fwPath) {
         validatePath(path);
         validatePath(fwPath);
+        validateTarget(target);
         SocketAddress targetAddress = getTargetAddress(target);
         createForwardRuleWithPath(path, targetAddress.getHost(), targetAddress.getPort(), targetAddress.getScheme(), fwPath);
     }
@@ -297,10 +300,12 @@ public class MockServer extends SlimFixture {
     }
 
     public HashMap<Integer, Object> recordedRequestsForPath(String path) {
+        validatePath(path);
         return arrayOfJsonObjectsToMap(mock.retrieveRecordedRequests(request().withPath(path)));
     }
 
     public int numberOfRequestsForPath(String path) {
+        validatePath(path);
         return mock.retrieveRecordedRequests(request().withPath(path)).length;
     }
 
@@ -309,6 +314,7 @@ public class MockServer extends SlimFixture {
     }
 
     public HashMap<Integer, Object> recordedRequestsAndResponsesForPath(String path) {
+        validatePath(path);
         return arrayOfJsonObjectsToMap(mock.retrieveRecordedRequestsAndResponses(request().withPath(path)));
     }
 
@@ -376,5 +382,10 @@ public class MockServer extends SlimFixture {
         }
     }
 
+    private void validateTarget(String target) {
+        if (!target.toLowerCase().matches("https?:\\/\\/.*(:[0-9]+)?")) {
+            throw new SlimFixtureException(false, "Invalid target input: " + target + ". Target should have the following format: http(s)://host[:port]");
+        }
+    }
 
 }


### PR DESCRIPTION
Zie https://trello.com/c/RYBEvwDz/5-mockserver-request-forward-obv-request-regel

Aangemaakte testen: [SupportForwardRules.txt](https://github.com/praegus/toolchain-fixtures/files/6036052/SupportForwardRules.txt)

Methode setForwardForToWithPath aangemaakt. 
