### PR TITLE
PauseTestFixture/PausePopupDialog: added commands to get/set "keep on top" (and its default).

### DIFF
--- a/src/main/java/nl/praegus/fitnesse/slim/fixtures/util/PausePopupDialog.java
+++ b/src/main/java/nl/praegus/fitnesse/slim/fixtures/util/PausePopupDialog.java
@@ -32,6 +32,8 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.lang.*;
+import java.util.prefs.*;
 
 @SuppressWarnings("serial")
 public class PausePopupDialog extends JDialog {
@@ -41,7 +43,11 @@ public class PausePopupDialog extends JDialog {
     private int value;
     private static Point center = null;
     private final JLabel label;
-    private static boolean keepOnTop = true;
+    private static boolean keepOnTop;
+
+    static {
+        keepOnTop = getKeepOnTopDefault();
+    }
 
     private synchronized void setValue(int value) {
         this.value = value;
@@ -63,6 +69,23 @@ public class PausePopupDialog extends JDialog {
         return center;
     }
 
+    private static Preferences getPreferences() {
+        Preferences prefs = Preferences.userRoot().node(PausePopupDialog.class.getName());
+        return prefs;
+    }
+    public static void setKeepOnTop(String value) {
+        PausePopupDialog.keepOnTop = Boolean.parseBoolean(value);
+    }
+    public static boolean getKeepOnTop() {
+        return PausePopupDialog.keepOnTop;
+    }
+    public static void setKeepOnTopDefault(String value) {
+        getPreferences().put("keepOnTop", value);    // store the string value
+    }
+    public static boolean getKeepOnTopDefault() {
+        String s = getPreferences().get("keepOnTop", "true");
+        return Boolean.parseBoolean(s);
+    }
     PausePopupDialog(Frame owner, String title, String message, String[] buttons) {
         super(owner, title, true);
 

--- a/src/main/java/nl/praegus/fitnesse/slim/fixtures/util/PauseTestFixture.java
+++ b/src/main/java/nl/praegus/fitnesse/slim/fixtures/util/PauseTestFixture.java
@@ -3,7 +3,24 @@ package nl.praegus.fitnesse.slim.fixtures.util;
 import nl.hsac.fitnesse.fixture.slim.SlimFixture;
 import nl.hsac.fitnesse.fixture.slim.StopTestException;
 
+import java.lang.*;
+
 public class PauseTestFixture extends SlimFixture {
+
+    public static void setKeepOnTopDefault(String value) {
+        PausePopupDialog.setKeepOnTopDefault(value);
+    }
+    public static boolean getKeepOnTopDefault() {
+        boolean b = PausePopupDialog.getKeepOnTopDefault();
+        return b;
+    }
+    public static void setKeepOnTop(String keepOnTop) {
+        PausePopupDialog.setKeepOnTop(keepOnTop);
+    }
+    public static boolean getKeepOnTop() {
+        boolean b = PausePopupDialog.getKeepOnTop();
+        return b;
+    }
 
     public void pause() throws StopTestException {
         pause("<no message>");


### PR DESCRIPTION
The pause popup dialog has a keepOnTop setting, that when true, prevents other windows from obscuring it.
Via a menu click this boolean setting can be changed.
Irrespective of that setting, each "pause" command shows the popup always on top; but once shown, the keepOnTop setting determines if it is allowed to be brought to the back (i.e. other windows obscuring it).
It's initial value, i.e. when a test first pops up the pause popup dialog, was hardcoded to be true .
That meant, that if you wanted to bring the pause popup to the back, you first had to do a menu click and then change the setting.
A command
<code>set keep on top default  (true|false)</code>
has been added, that will allow to specify the default value. This default value will be stored on the computer system, and will be used in future Fitnesse test runs.
(see  https://docs.oracle.com/javase%2F7%2Fdocs%2Fapi%2F%2F/java/util/prefs/Preferences.html )
Also a command
<code>set keep on top (true|false)</code>
is added, for the current used value of keepOnTop .
And getters for both the current and default .
